### PR TITLE
Fix stack trace empty frames

### DIFF
--- a/src/Hautelook/SentryClient/Request/Interfaces/StackTrace.php
+++ b/src/Hautelook/SentryClient/Request/Interfaces/StackTrace.php
@@ -39,10 +39,16 @@ class StackTrace implements ToArrayInterface
      */
     public function toArray()
     {
+        $frames = array_map(function (Frame $frame) {
+            return $frame->toArray();
+        }, $this->getFrames());
+
+        if (count($frames) < 1) {
+            $frames = new \ArrayObject(); // the sentry api would prefer an empty object rather than an empty array
+        }
+
         return array(
-            'frames' => array_map(function (Frame $frame) {
-                return $frame->toArray();
-            }, $this->getFrames()),
+            'frames' => $frames,
         );
     }
 }

--- a/tests/Hautelook/SentryClient/Tests/Request/Interfaces/StackTraceTest.php
+++ b/tests/Hautelook/SentryClient/Tests/Request/Interfaces/StackTraceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Hautelook\SentryClient\Tests\Request\Interfaces;
+
+use Hautelook\SentryClient\Request\Interfaces\StackTrace;
+
+class StackTraceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmpty()
+    {
+        $stackTrace = new StackTrace(array());
+
+        $this->assertEquals(array('frames' => new \ArrayObject()), $stackTrace->toArray());
+        $this->assertSame('{"frames":{}}', json_encode($stackTrace->toArray()));
+    }
+}


### PR DESCRIPTION
From @dcramer:

> Hey Adrien
>
> Noticed a bug your client is sending through to Sentry.
>
> In some situations the ‘frame’ object is empty. In this case instead of passing {} to the server (which is invalid, but expected), its passing []. I’m assuming this is PHP and its just not handling the empty case.
