### PR TITLE
Make attributes compatible with API

### DIFF
--- a/src/Hautelook/SentryClient/Command/CaptureCommand.php
+++ b/src/Hautelook/SentryClient/Command/CaptureCommand.php
@@ -39,7 +39,7 @@ class CaptureCommand extends OperationCommand
         if ($this['timestamp'] instanceof \DateTime) {
             $this['timestamp'] = clone $this['timestamp'];
             $this['timestamp']->setTimezone(new \DateTimeZone('UTC'));
-            $this['timestamp'] = $this['timestamp']->format(\DateTime::ISO8601);
+            $this['timestamp'] = $this['timestamp']->format('Y-m-d\TH:i:s');
         }
 
         $factory = new VisitorFlyweight();

--- a/src/Hautelook/SentryClient/Command/CaptureCommand.php
+++ b/src/Hautelook/SentryClient/Command/CaptureCommand.php
@@ -30,7 +30,7 @@ class CaptureCommand extends OperationCommand
                 $uuid = Uuid::uuid4();
             }
 
-            $this['event_id'] = $uuid->toString();
+            $this['event_id'] = str_replace('-', '', $uuid->toString());
         }
 
         if (!isset($this['timestamp'])) {


### PR DESCRIPTION
Sentry encounters three errors in the events send by this client:
<img width="919" alt="screen shot 2016-07-12 at 13 55 23" src="https://cloud.githubusercontent.com/assets/250662/16766114/611fa2ce-4838-11e6-9f9c-b172359a9e9c.png">

The attributes aren't compatible with the Sentry API: https://docs.getsentry.com/hosted/clientdev/attributes/

I fixed the first two errors (``event_id`` and ``timestamp``). I couldn't find a solution for ``extra``.